### PR TITLE
Add average measurements

### DIFF
--- a/firmware/temperature_detection/temperature_detection.ino
+++ b/firmware/temperature_detection/temperature_detection.ino
@@ -18,8 +18,8 @@ typedef enum {
 
 
 void display_status(status indicators);
-float measure_temperature(size_t samples);
-int measure_distance(size_t samples);
+float measure_temperature(size_t samples, int interval);
+int measure_distance(size_t samples, int interval);
 
 Adafruit_MLX90614 temperature_sensor = Adafruit_MLX90614();
 
@@ -73,7 +73,7 @@ void loop() {
 }
 
 
-int measure_distance(size_t samples) {
+int measure_distance(size_t samples, int interval) {
     float measurements = 0;
     for(size_t counter = 0; counter < (samples || 1); counter++) {
         digitalWrite(ultrasound_trigger_pin, LOW);
@@ -83,15 +83,17 @@ int measure_distance(size_t samples) {
         digitalWrite(ultrasound_trigger_pin, LOW);
         long duration = pulseIn(ultrasound_echo_pin, HIGH);
         measurements += duration * 0.034 / 2;
+        delay(interval);
     }
     return measurements / (samples || 1); // average in centimeters
 }
 
 
-float measure_temperature(size_t samples) {
+float measure_temperature(size_t samples, int interval) {
     float measurements = 0;
     for(size_t counter = 0; counter < (samples || 1); counter++) {
         measurements += temperature_sensor.readObjectTempC();
+        delay(interval);
     }
     return measurements / (samples || 1); // average in celsius degrees
 }

--- a/firmware/temperature_detection/temperature_detection.ino
+++ b/firmware/temperature_detection/temperature_detection.ino
@@ -43,7 +43,7 @@ void setup() {
 
 
 void loop() {
-    int distance = measure_distance(distance_samples);
+    int distance = measure_distance(distance_samples, distance_interval);
     Serial.println("distance");
     Serial.println(distance);
 
@@ -60,13 +60,13 @@ void loop() {
         display_status(STATUS_DISTANCE_RIGHT);
         delay(time_before_sensor_stab); // Wait for the sensor to stabilize.
         Serial.println("Temperature measurement");
-        Serial.println(measure_temperature(temperature_samples));
+        Serial.println(measure_temperature(temperature_samples, temperature_interval));
         display_status(
-            (measure_temperature(temperature_samples) > limit_fever)
+            (measure_temperature(temperature_samples, temperature_interval) > limit_fever)
             ? STATUS_FEVER_HIGH : STATUS_FEVER_LOW
         );
         // Wait for the person to go away...
-        while(measure_distance(distance_samples) <= next_person_distance) {
+        while(measure_distance(distance_samples, distance_interval) <= next_person_distance) {
             delay(time_before_leaving);
         }
     }

--- a/firmware/temperature_detection/temperature_detection.ino
+++ b/firmware/temperature_detection/temperature_detection.ino
@@ -17,12 +17,14 @@ typedef enum {
 } status;
 
 
-int measure_distance();
-float measure_temperature();
 void display_status(status indicators);
+float measure_temperature(size_t samples);
+int measure_distance(size_t samples);
+
 Adafruit_MLX90614 temperature_sensor = Adafruit_MLX90614();
 
-void setup() {    
+
+void setup() {
     pinMode(ultrasound_echo_pin, INPUT);
     pinMode(ultrasound_trigger_pin, OUTPUT);
     pinMode(green_indicator_pin, OUTPUT);
@@ -30,7 +32,7 @@ void setup() {
     pinMode(red_indicator_pin, OUTPUT);
 
     Serial.begin(serial_monitor_speed);
-    
+
     #ifdef ESP32
         Wire.begin(sda_pin, scl_pin);
     #else
@@ -41,7 +43,7 @@ void setup() {
 
 
 void loop() {
-    int distance = measure_distance();
+    int distance = measure_distance(distance_samples);
     Serial.println("distance");
     Serial.println(distance);
 
@@ -58,31 +60,42 @@ void loop() {
         display_status(STATUS_DISTANCE_RIGHT);
         delay(time_before_sensor_stab); // Wait for the sensor to stabilize.
         Serial.println("Temperature measurement");
-        Serial.println(measure_temperature());
+        Serial.println(measure_temperature(temperature_samples));
         display_status(
-            (measure_temperature() > limit_fever)
+            (measure_temperature(temperature_samples) > limit_fever)
             ? STATUS_FEVER_HIGH : STATUS_FEVER_LOW
         );
         // Wait for the person to go away...
-        while(measure_distance() <= next_person_distance) delay(time_before_leaving);
+        while(measure_distance(distance_samples) <= next_person_distance) {
+            delay(time_before_leaving);
+        }
     }
 }
 
 
-int measure_distance() {
-    digitalWrite(ultrasound_trigger_pin, LOW);
-    delayMicroseconds(2);
-    digitalWrite(ultrasound_trigger_pin, HIGH);
-    delayMicroseconds(10);
-    digitalWrite(ultrasound_trigger_pin, LOW);
-    long duration = pulseIn(ultrasound_echo_pin, HIGH);
-    int distance = duration * 0.034 / 2;
-    return distance; // in centimeters
+int measure_distance(size_t samples) {
+    if(samples == 0) samples = 1; // sanity check
+    float measurements = 0;
+    for(size_t counter = 0; counter < samples; counter++) {
+        digitalWrite(ultrasound_trigger_pin, LOW);
+        delayMicroseconds(2);
+        digitalWrite(ultrasound_trigger_pin, HIGH);
+        delayMicroseconds(10);
+        digitalWrite(ultrasound_trigger_pin, LOW);
+        long duration = pulseIn(ultrasound_echo_pin, HIGH);
+        measurements += duration * 0.034 / 2;
+    }
+    return measurements / samples; // average in centimeters
 }
 
 
-float measure_temperature() {
-    return temperature_sensor.readObjectTempC(); // in celsius degrees
+float measure_temperature(size_t samples) {
+    if(samples == 0) samples = 1; // sanity check
+    float measurements = 0;
+    for(size_t counter = 0; counter < samples; counter++) {
+        measurements += temperature_sensor.readObjectTempC();
+    }
+    return measurements / samples; // average in celsius degrees
 }
 
 

--- a/firmware/temperature_detection/temperature_detection.ino
+++ b/firmware/temperature_detection/temperature_detection.ino
@@ -74,9 +74,8 @@ void loop() {
 
 
 int measure_distance(size_t samples) {
-    if(samples == 0) samples = 1; // sanity check
     float measurements = 0;
-    for(size_t counter = 0; counter < samples; counter++) {
+    for(size_t counter = 0; counter < (samples || 1); counter++) {
         digitalWrite(ultrasound_trigger_pin, LOW);
         delayMicroseconds(2);
         digitalWrite(ultrasound_trigger_pin, HIGH);
@@ -85,17 +84,16 @@ int measure_distance(size_t samples) {
         long duration = pulseIn(ultrasound_echo_pin, HIGH);
         measurements += duration * 0.034 / 2;
     }
-    return measurements / samples; // average in centimeters
+    return measurements / (samples || 1); // average in centimeters
 }
 
 
 float measure_temperature(size_t samples) {
-    if(samples == 0) samples = 1; // sanity check
     float measurements = 0;
-    for(size_t counter = 0; counter < samples; counter++) {
+    for(size_t counter = 0; counter < (samples || 1); counter++) {
         measurements += temperature_sensor.readObjectTempC();
     }
-    return measurements / samples; // average in celsius degrees
+    return measurements / (samples || 1); // average in celsius degrees
 }
 
 

--- a/firmware/temperature_detection/user_config.h
+++ b/firmware/temperature_detection/user_config.h
@@ -14,8 +14,10 @@
 #define red_indicator_pin       6 // if you want to use the built in UNO led you can set 13
 
 // Sampling average size
-#define temperature_samples  3
-#define distance_samples     5
+#define temperature_samples     3
+#define temperature_interval    250 // need to be confirmed
+#define distance_samples        5
+#define distance_interval       100 // 60ms minimum recommended in the Sparkfun datasheet of HC-SR04
 
 #ifdef ESP32 // pin definition for ESP32 only
 #define sda_pin                 0

--- a/firmware/temperature_detection/user_config.h
+++ b/firmware/temperature_detection/user_config.h
@@ -13,6 +13,10 @@
 #define orange_indicator_pin    5
 #define red_indicator_pin       6 // if you want to use the built in UNO led you can set 13
 
+// Sampling average size
+#define temperature_samples  3
+#define distance_samples     5
+
 #ifdef ESP32 // pin definition for ESP32 only
 #define sda_pin                 0
 #define scl_pin                 26


### PR DESCRIPTION
Now, `measure_distance` and `measure_temperature` functions take a `samples` argument that determines the number of samples taken in each measurement. This should avoid erratic behavior in case of interference and provide better temperature data.