### PR TITLE
Add LCD color display to M5StickC

### DIFF
--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -21,6 +21,7 @@ src_dir = temperature_detection
 ;default_envs = uno
 ;default_envs = atmega
 ;default_envs = m5stickc
+;default_envs = m5stickc-lcd
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                              ENVIRONMENTS PARAMETERS                                 ;
@@ -30,6 +31,7 @@ src_dir = temperature_detection
 
 [libraries]
 MLX90614 = Adafruit MLX90614 Library@1.0.1
+m5stickc = M5StickC@0.2.0
 
 [env]
 framework = arduino
@@ -70,8 +72,20 @@ platform = ${com.esp32_platform}
 board = m5stick-c
 lib_deps =
   ${env.lib_deps}
+  ${libraries.m5stickc}
 build_flags =
   ${env.build_flags}
   '-DINVERT_INDICATORS'
   '-DBUTTON_PIN=37'
   '-DRED_INDICATOR_PIN=10'
+
+[env:m5stickc-lcd]
+platform = ${com.esp32_platform}
+board = m5stick-c
+lib_deps =
+  ${env.lib_deps}
+  ${libraries.m5stickc}
+build_flags =
+  ${env.build_flags}
+  '-DM5STICKC'
+  '-DBUTTON_PIN=37'

--- a/firmware/temperature_detection/temperature_detection.ino
+++ b/firmware/temperature_detection/temperature_detection.ino
@@ -1,6 +1,8 @@
 #include "user_config.h"
 #include <Adafruit_MLX90614.h>
-
+#ifdef M5STICKC
+#include <M5StickC.h>
+#endif
 
 typedef enum {
     INDICATOR_RED = 1 << 0,
@@ -9,8 +11,8 @@ typedef enum {
 } indicator;
 
 typedef enum {
-    STATUS_FEVER_LOW = INDICATOR_ORANGE | INDICATOR_GREEN,
-    STATUS_FEVER_HIGH = INDICATOR_ORANGE | INDICATOR_RED,
+    STATUS_FEVER_LOW = INDICATOR_GREEN,
+    STATUS_FEVER_HIGH = INDICATOR_RED,
     STATUS_DISTANCE_RIGHT = INDICATOR_GREEN,
     STATUS_DISTANCE_WRONG = INDICATOR_ORANGE,
     STATUS_TRIGGER = STATUS_DISTANCE_RIGHT,
@@ -28,11 +30,19 @@ Adafruit_MLX90614 temperature_sensor = Adafruit_MLX90614();
 
 
 void setup() {
-    pinMode(ULTRASOUND_ECHO_PIN, INPUT);
-    pinMode(ULTRASOUND_TRIGGER_PIN, OUTPUT);
-    pinMode(GREEN_INDICATOR_PIN, OUTPUT);
-    pinMode(ORANGE_INDICATOR_PIN, OUTPUT);
-    pinMode(RED_INDICATOR_PIN, OUTPUT);
+
+    #ifdef M5STICKC
+        Serial.println("Setup M5StickC");
+        M5.begin();
+        M5.Lcd.fillScreen(TFT_WHITE);
+    #else
+        pinMode(ULTRASOUND_ECHO_PIN, INPUT);
+        pinMode(ULTRASOUND_TRIGGER_PIN, OUTPUT);
+        pinMode(GREEN_INDICATOR_PIN, OUTPUT);
+        pinMode(ORANGE_INDICATOR_PIN, OUTPUT);
+        pinMode(RED_INDICATOR_PIN, OUTPUT);
+    #endif
+
     pinMode(BUTTON_PIN, INPUT_PULLUP);
 
     Serial.begin(SERIAL_MONITOR_SPEED);
@@ -143,6 +153,12 @@ void display_status(status indicators) {
     #ifdef INVERT_INDICATORS
         indicators = (status)~indicators;
     #endif
+    #ifdef M5STICKC
+    (indicators & INDICATOR_RED)
+        ? M5.Lcd.fillScreen(TFT_RED) : ((indicators & INDICATOR_ORANGE)
+            ? M5.Lcd.fillScreen(TFT_ORANGE) : ((indicators & INDICATOR_GREEN)
+                ? M5.Lcd.fillScreen(TFT_GREEN) : M5.Lcd.fillScreen(TFT_WHITE)));
+    #else
     digitalWrite(
         RED_INDICATOR_PIN,
         (indicators & INDICATOR_RED)
@@ -158,4 +174,6 @@ void display_status(status indicators) {
         (indicators & INDICATOR_GREEN)
         ? HIGH : LOW
     );
+    #endif
 }
+

--- a/firmware/temperature_detection/temperature_detection.ino
+++ b/firmware/temperature_detection/temperature_detection.ino
@@ -32,12 +32,20 @@ Adafruit_MLX90614 temperature_sensor = Adafruit_MLX90614();
 void setup() {
     Serial.begin(SERIAL_MONITOR_SPEED);
     
-    pinMode(ULTRASOUND_ECHO_PIN, INPUT);
-    pinMode(ULTRASOUND_TRIGGER_PIN, OUTPUT);
-    pinMode(GREEN_INDICATOR_PIN, OUTPUT);
-    pinMode(ORANGE_INDICATOR_PIN, OUTPUT);
-    pinMode(RED_INDICATOR_PIN, OUTPUT);
-    pinMode(BUTTON_PIN, INPUT_PULLUP);
+    #ifdef ENABLE_SONAR
+        pinMode(ULTRASOUND_ECHO_PIN, INPUT);
+        pinMode(ULTRASOUND_TRIGGER_PIN, OUTPUT);
+    #endif
+
+    #ifdef ENABLE_INDICATORS
+        pinMode(GREEN_INDICATOR_PIN, OUTPUT);
+        pinMode(ORANGE_INDICATOR_PIN, OUTPUT);
+        pinMode(RED_INDICATOR_PIN, OUTPUT);
+    #endif
+
+    #ifdef ENABLE_BUTTON
+        pinMode(BUTTON_PIN, INPUT_PULLUP);
+    #endif
 
     #ifdef M5STICKC
         M5.begin();
@@ -150,15 +158,15 @@ void display_status(status indicators) {
         indicators = (status)~indicators;
     #endif
     #ifdef M5STICKC
-        M5.Lcd.fillRect(0, 0, 106, 240,
+        M5.Lcd.fillRect(0, 0, 80, 53,
             (indicators & INDICATOR_RED)
             ? TFT_RED : TFT_BLACK
         );
-        M5.Lcd.fillRect(107, 0, 213, 240,
+        M5.Lcd.fillRect(0, 53, 80, 53,
             (indicators & INDICATOR_ORANGE)
             ? TFT_ORANGE : TFT_BLACK
         );
-        M5.Lcd.fillRect(214, 0, 320, 240,
+        M5.Lcd.fillRect(0, 106, 80, 54,
             (indicators & INDICATOR_GREEN)
             ? TFT_GREEN : TFT_BLACK
         );

--- a/firmware/temperature_detection/temperature_detection.ino
+++ b/firmware/temperature_detection/temperature_detection.ino
@@ -11,8 +11,8 @@ typedef enum {
 } indicator;
 
 typedef enum {
-    STATUS_FEVER_LOW = INDICATOR_GREEN,
-    STATUS_FEVER_HIGH = INDICATOR_RED,
+    STATUS_FEVER_LOW = INDICATOR_ORANGE | INDICATOR_GREEN,
+    STATUS_FEVER_HIGH = INDICATOR_ORANGE | INDICATOR_RED,
     STATUS_DISTANCE_RIGHT = INDICATOR_GREEN,
     STATUS_DISTANCE_WRONG = INDICATOR_ORANGE,
     STATUS_TRIGGER = STATUS_DISTANCE_RIGHT,
@@ -30,22 +30,18 @@ Adafruit_MLX90614 temperature_sensor = Adafruit_MLX90614();
 
 
 void setup() {
-
-    #ifdef M5STICKC
-        Serial.println("Setup M5StickC");
-        M5.begin();
-        M5.Lcd.fillScreen(TFT_WHITE);
-    #else
-        pinMode(ULTRASOUND_ECHO_PIN, INPUT);
-        pinMode(ULTRASOUND_TRIGGER_PIN, OUTPUT);
-        pinMode(GREEN_INDICATOR_PIN, OUTPUT);
-        pinMode(ORANGE_INDICATOR_PIN, OUTPUT);
-        pinMode(RED_INDICATOR_PIN, OUTPUT);
-    #endif
-
+    Serial.begin(SERIAL_MONITOR_SPEED);
+    
+    pinMode(ULTRASOUND_ECHO_PIN, INPUT);
+    pinMode(ULTRASOUND_TRIGGER_PIN, OUTPUT);
+    pinMode(GREEN_INDICATOR_PIN, OUTPUT);
+    pinMode(ORANGE_INDICATOR_PIN, OUTPUT);
+    pinMode(RED_INDICATOR_PIN, OUTPUT);
     pinMode(BUTTON_PIN, INPUT_PULLUP);
 
-    Serial.begin(SERIAL_MONITOR_SPEED);
+    #ifdef M5STICKC
+        M5.begin();
+    #endif
 
     #ifdef ESP32
         Wire.begin(ESP32_SDA_PIN, ESP32_SCL_PIN);
@@ -154,26 +150,34 @@ void display_status(status indicators) {
         indicators = (status)~indicators;
     #endif
     #ifdef M5STICKC
-    (indicators & INDICATOR_RED)
-        ? M5.Lcd.fillScreen(TFT_RED) : ((indicators & INDICATOR_ORANGE)
-            ? M5.Lcd.fillScreen(TFT_ORANGE) : ((indicators & INDICATOR_GREEN)
-                ? M5.Lcd.fillScreen(TFT_GREEN) : M5.Lcd.fillScreen(TFT_WHITE)));
+        M5.Lcd.fillRect(0, 0, 106, 240,
+            (indicators & INDICATOR_RED)
+            ? TFT_RED : TFT_BLACK
+        );
+        M5.Lcd.fillRect(107, 0, 213, 240,
+            (indicators & INDICATOR_ORANGE)
+            ? TFT_ORANGE : TFT_BLACK
+        );
+        M5.Lcd.fillRect(214, 0, 320, 240,
+            (indicators & INDICATOR_GREEN)
+            ? TFT_GREEN : TFT_BLACK
+        );
     #else
-    digitalWrite(
-        RED_INDICATOR_PIN,
-        (indicators & INDICATOR_RED)
-        ? HIGH : LOW
-    );
-    digitalWrite(
-        ORANGE_INDICATOR_PIN,
-        (indicators & INDICATOR_ORANGE)
-        ? HIGH : LOW
-    );
-    digitalWrite(
-        GREEN_INDICATOR_PIN,
-        (indicators & INDICATOR_GREEN)
-        ? HIGH : LOW
-    );
+        digitalWrite(
+            RED_INDICATOR_PIN,
+            (indicators & INDICATOR_RED)
+            ? HIGH : LOW
+        );
+        digitalWrite(
+            ORANGE_INDICATOR_PIN,
+            (indicators & INDICATOR_ORANGE)
+            ? HIGH : LOW
+        );
+        digitalWrite(
+            GREEN_INDICATOR_PIN,
+            (indicators & INDICATOR_GREEN)
+            ? HIGH : LOW
+        );
     #endif
 }
 

--- a/firmware/temperature_detection/temperature_detection.ino
+++ b/firmware/temperature_detection/temperature_detection.ino
@@ -162,22 +162,21 @@ void display_status(status indicators) {
             (indicators & INDICATOR_GREEN)
             ? TFT_GREEN : TFT_BLACK
         );
-    #else
-        digitalWrite(
-            RED_INDICATOR_PIN,
-            (indicators & INDICATOR_RED)
-            ? HIGH : LOW
-        );
-        digitalWrite(
-            ORANGE_INDICATOR_PIN,
-            (indicators & INDICATOR_ORANGE)
-            ? HIGH : LOW
-        );
-        digitalWrite(
-            GREEN_INDICATOR_PIN,
-            (indicators & INDICATOR_GREEN)
-            ? HIGH : LOW
-        );
     #endif
+    digitalWrite(
+        RED_INDICATOR_PIN,
+        (indicators & INDICATOR_RED)
+        ? HIGH : LOW
+    );
+    digitalWrite(
+        ORANGE_INDICATOR_PIN,
+        (indicators & INDICATOR_ORANGE)
+        ? HIGH : LOW
+    );
+    digitalWrite(
+        GREEN_INDICATOR_PIN,
+        (indicators & INDICATOR_GREEN)
+        ? HIGH : LOW
+    );
 }
 

--- a/firmware/temperature_detection/user_config.h
+++ b/firmware/temperature_detection/user_config.h
@@ -5,6 +5,9 @@
 // #define ENABLE_SONAR 
 // #define INVERT_INDICATORS
 
+// Boards
+// #define M5STICKC 
+
 // Times (bauds and milliseconds)
 #define SERIAL_MONITOR_SPEED        9600
 #define SENSOR_STABILIZATION_TIME   100

--- a/firmware/temperature_detection/user_config.h
+++ b/firmware/temperature_detection/user_config.h
@@ -7,6 +7,19 @@
 
 // Boards
 // #define M5STICKC 
+// #define ANOTHER 
+
+#ifdef M5STICKC
+    #define ENABLE_BUTTON
+    #undef ENABLE_INDICATORS
+    #undef ENABLE_SONAR
+#endif
+
+#ifdef ANOTHER
+    //#define ENABLE_BUTTON
+    #define ENABLE_INDICATORS
+    #define ENABLE_SONAR
+#endif
 
 // Times (bauds and milliseconds)
 #define SERIAL_MONITOR_SPEED        9600


### PR DESCRIPTION
Display simple colors instead of led usage (RED/GREEN)
RED when fever is detected after a button push
GREEN when there is no fever after a button push

I have changed indicator enum due to the fact that the ESP was showing ORANGE screen when fever was low.

This is a first approach to introduce LCD management, after this we may display temperature.